### PR TITLE
Improved error handling and logging

### DIFF
--- a/v1/errors/errors.go
+++ b/v1/errors/errors.go
@@ -13,6 +13,11 @@ const fieldErrorsKey = "field_errors"
 
 type Code string
 
+type Responder interface {
+	error
+	Response() *router.Response
+}
+
 type Error struct {
 	Status  int                    `json:"-"`
 	Code    Code                   `json:"code,omitempty"`

--- a/v1/rest.go
+++ b/v1/rest.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	syserrs "errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -191,23 +192,12 @@ func (s *Service) handler(route *router.Route) Handler {
 			return rsp, nil
 		}
 
-		var cause error
-		if c, ok := err.(*errors.Error); ok {
-			cause = c.Cause
-		}
-
-		var elog *logrus.Entry
-		if cause == nil {
-			elog = s.log.WithFields(logrus.Fields{})
-		} else {
-			elog = s.log.WithFields(logrus.Fields{
-				"because": cause.Error(),
-			})
-		}
-
+		elog := errlog(s.log, err)
 		elog.Errorf("%s: %v", resource(req), err)
-		if c, ok := err.(*errors.Error); ok {
-			return c.Response(), nil
+
+		var rsperr errors.Responder
+		if syserrs.As(err, &rsperr) {
+			return rsperr.Response(), nil
 		} else {
 			return rsp, err
 		}
@@ -245,4 +235,25 @@ func resource(req *router.Request) string {
 		r += fmt.Sprintf("?%s", p)
 	}
 	return r
+}
+
+// Produce a logger for an error
+func errlog(log *logrus.Logger, err error) *logrus.Entry {
+	fields := make(logrus.Fields)
+
+	for n := 0; ; n++ {
+		var resterr *errors.Error
+		if !syserrs.As(err, &resterr) {
+			break
+		}
+		cause := resterr.Unwrap()
+		name := "because"
+		if n > 0 {
+			name = name + fmt.Sprintf("_%d", n)
+		}
+		fields[name] = cause.Error()
+		err = cause
+	}
+
+	return log.WithFields(fields)
 }

--- a/v1/rest.go
+++ b/v1/rest.go
@@ -241,7 +241,7 @@ func resource(req *router.Request) string {
 func errlog(log *logrus.Logger, err error) *logrus.Entry {
 	fields := make(logrus.Fields)
 
-	for n := 0; ; n++ {
+	for n := 0; err != nil; n++ {
 		var resterr *errors.Error
 		if !syserrs.As(err, &resterr) {
 			break

--- a/v1/rest_test.go
+++ b/v1/rest_test.go
@@ -1,13 +1,16 @@
 package rest
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/bww/go-rest/v1/errors"
 	"github.com/bww/go-router/v1"
 	"github.com/bww/go-router/v1/entity"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -167,4 +170,20 @@ func BenchmarkService(b *testing.B) {
 		rec = httptest.NewRecorder()
 		s.ServeHTTP(rec, reqB)
 	}
+}
+
+func TestUnwrapErrors(t *testing.T) {
+	err4 := fmt.Errorf("Error #4")
+	err3 := fmt.Errorf("Error #3: %w", err4)
+	err2 := errors.Errorf(http.StatusBadRequest, "Error #2").SetCause(err3)
+	err1 := errors.Errorf(http.StatusBadRequest, "Error #1").SetCause(err2)
+	err0 := errors.Errorf(http.StatusBadRequest, "Error #0").SetCause(err1)
+
+	entry := errlog(&logrus.Logger{}, err0)
+	assert.Equal(t, logrus.Fields{
+		"because":   "Error #1",
+		"because_1": "Error #2",
+		"because_2": "Error #3: Error #4",
+		// next error is not unwrapped because it is not an errors.Error
+	}, entry.Data)
 }


### PR DESCRIPTION
This update makes two changes:

1. All errors of type `github.com/bww/go-rest/*errors.Error` in the chain are unwrapped and logged, not just the first one; and
2. A new interface,`Responder`, has been added to generalize responding with a specialized error response; any error that implements this interface will respond with the returned response instead of a generic error message.
